### PR TITLE
Endurece la CSP: quita unsafe-inline de script-src y style-src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# Artefactos de sesiones de Playwright MCP (snapshots de depuración)
+.playwright-mcp/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,8 +13,10 @@ export default defineConfig({
       filter: (page) => !page.includes('/admin'),
     }),
   ],
-  // Optimización para producción
+  // 'never' (en vez de 'auto'): ningún <style> inline en el HTML, todo el CSS
+  // como <link> externo — permite quitar 'unsafe-inline' de style-src en la CSP
+  // (netlify.toml) sin depender de hashes por página.
   build: {
-    inlineStylesheets: 'auto',
+    inlineStylesheets: 'never',
   },
 });

--- a/netlify.toml
+++ b/netlify.toml
@@ -37,7 +37,7 @@
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
-    Content-Security-Policy = "default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'"
+    Content-Security-Policy = "default-src 'self'; img-src 'self' data: https:; style-src 'self'; script-src 'self'"
 
 # Assets con hash en el nombre (JS/CSS/fuentes/imágenes de _astro): son
 # inmutables, cualquier cambio de contenido genera un fichero nuevo.

--- a/public/scripts/asignaturas.js
+++ b/public/scripts/asignaturas.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', () => {
+	const selectNivel = document.getElementById('nivel');
+	const selectAnio = document.getElementById('anioAcademico');
+	const inputBusqueda = document.getElementById('busqueda');
+	const cards = document.querySelectorAll('.subject-card');
+	const noResults = document.getElementById('noResults');
+	const resultCount = document.getElementById('resultCount');
+
+	const sections = document.querySelectorAll('.subject-section');
+
+	function applyFilters() {
+		const nivel = selectNivel?.value || 'todos';
+		const anio = selectAnio?.value || 'todos';
+		const busqueda = (inputBusqueda?.value || '').toLowerCase().trim();
+
+		let visible = 0;
+		cards.forEach((card) => {
+			const matchNivel = nivel === 'todos' || card.dataset.nivel === nivel;
+			const matchAnio = anio === 'todos' || card.dataset.anio === anio;
+			const matchBusqueda = !busqueda || (card.dataset.search || '').includes(busqueda);
+			const show = matchNivel && matchAnio && matchBusqueda;
+			card.classList.toggle('hidden', !show);
+			if (show) visible++;
+		});
+
+		// Oculta también la cabecera de un curso si ningún resultado suyo pasa el filtro.
+		sections.forEach((section) => {
+			const hasVisible = !!section.querySelector('.subject-card:not(.hidden)');
+			section.classList.toggle('hidden', !hasVisible);
+		});
+
+		if (resultCount) resultCount.textContent = `(${visible})`;
+		noResults?.classList.toggle('hidden', visible !== 0);
+	}
+
+	selectNivel?.addEventListener('change', applyFilters);
+	selectAnio?.addEventListener('change', applyFilters);
+	inputBusqueda?.addEventListener('input', applyFilters);
+});

--- a/public/scripts/contacto.js
+++ b/public/scripts/contacto.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', function () {
+	const form = document.getElementById('contact-form');
+	const submitButton = form?.querySelector('button[type="submit"]');
+	const feedback = document.getElementById('form-feedback');
+	const feedbackTitle = document.getElementById('form-feedback-title');
+	const feedbackText = document.getElementById('form-feedback-text');
+
+	if (form && submitButton && feedback && feedbackTitle && feedbackText) {
+		form.addEventListener('submit', function (event) {
+			event.preventDefault();
+			submitButton.disabled = true;
+			submitButton.textContent = 'Enviando...';
+
+			const formData = new FormData(form);
+
+			fetch('/', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+				body: new URLSearchParams(formData).toString(),
+			})
+				.then(() => {
+					form.classList.add('hidden');
+					feedback.classList.remove('hidden');
+					feedbackTitle.textContent = 'Mensaje enviado con exito';
+					feedbackText.textContent = 'Gracias por contactar. Te respondere en 24-48 horas.';
+				})
+				.catch(() => {
+					submitButton.disabled = false;
+					submitButton.textContent = 'Enviar mensaje';
+					feedback.classList.remove('hidden');
+					feedbackTitle.textContent = 'Error al enviar';
+					feedbackText.textContent = 'Intenta de nuevo o escribe a roberto.sanchez@uclm.es';
+				});
+		});
+	}
+});

--- a/public/scripts/publicaciones.js
+++ b/public/scripts/publicaciones.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', function () {
+	const yearFilter = document.getElementById('yearFilter');
+	const sortOrder = document.getElementById('sortOrder');
+	const publicationsList = document.getElementById('publicationsList');
+	const publicationItems = document.querySelectorAll('.publication-item');
+
+	function filterPublications() {
+		if (!yearFilter) return;
+		const selectedYear = yearFilter.value;
+
+		publicationItems.forEach((item) => {
+			const match = !selectedYear || item.dataset.year === selectedYear;
+			item.classList.toggle('hidden', !match);
+		});
+	}
+
+	function sortPublications() {
+		if (!sortOrder || !publicationsList) return;
+
+		const items = Array.from(publicationItems);
+		if (sortOrder.value === 'citations-desc') {
+			items.sort((a, b) => parseInt(b.dataset.citations || '0') - parseInt(a.dataset.citations || '0'));
+		} else {
+			// Orden original del JSON (Scholar: fecha de publicación descendente)
+			items.sort((a, b) => parseInt(b.dataset.year || '0') - parseInt(a.dataset.year || '0'));
+		}
+
+		items.forEach((item) => publicationsList.appendChild(item));
+	}
+
+	yearFilter?.addEventListener('change', filterPublications);
+	sortOrder?.addEventListener('change', sortPublications);
+
+	// Orden inicial: más citadas, todos los años
+	sortPublications();
+});

--- a/public/scripts/site.js
+++ b/public/scripts/site.js
@@ -1,0 +1,113 @@
+document.addEventListener('DOMContentLoaded', () => {
+	// Toggle de tema — puede haber varios botones .theme-toggle en la página
+	// (nav de escritorio y menú móvil). La lectura inicial y aplicación del
+	// tema ya la hace theme-init.js antes del primer render.
+	const html = document.documentElement;
+
+	document.querySelectorAll('.theme-toggle').forEach((toggle) => {
+		toggle.addEventListener('click', () => {
+			const next = html.classList.contains('dark') ? 'light' : 'dark';
+			html.classList.toggle('dark');
+			localStorage.setItem('theme', next);
+		});
+	});
+
+	window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+		if (!localStorage.getItem('theme')) {
+			html.classList.toggle('dark', e.matches);
+		}
+	});
+
+	// Botón "volver arriba"
+	const backToTop = document.getElementById('back-to-top');
+	if (backToTop) {
+		const toggleBackToTop = () => {
+			const show = window.scrollY > 400;
+			backToTop.classList.toggle('!opacity-100', show);
+			backToTop.classList.toggle('!translate-y-0', show);
+			backToTop.classList.toggle('!pointer-events-auto', show);
+		};
+		window.addEventListener('scroll', toggleBackToTop, { passive: true });
+		backToTop.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
+	}
+
+	// Menú móvil (hamburguesa)
+	const mobileMenuButton = document.getElementById('mobile-menu-button');
+	const mobileMenu = document.getElementById('mobile-menu');
+
+	if (mobileMenuButton && mobileMenu) {
+		let isOpen = false;
+
+		const setOpen = (open, restoreFocus = false) => {
+			isOpen = open;
+			mobileMenu.classList.toggle('hidden', !open);
+			mobileMenuButton.setAttribute('aria-expanded', String(open));
+
+			if (open) {
+				mobileMenu.querySelector('a')?.focus();
+			} else if (restoreFocus) {
+				mobileMenuButton.focus();
+			}
+		};
+
+		mobileMenuButton.addEventListener('click', () => setOpen(!isOpen));
+
+		mobileMenu.querySelectorAll('a').forEach((link) => {
+			link.addEventListener('click', () => setOpen(false));
+		});
+
+		mobileMenu.addEventListener('keydown', (event) => {
+			if (event.key === 'Escape') setOpen(false, true);
+		});
+
+		window.addEventListener('resize', () => {
+			if (window.innerWidth >= 768 && isOpen) setOpen(false);
+		});
+	}
+
+	// Estilos dinámicos por dato (evita style="" inline, incompatible con
+	// CSP style-src sin 'unsafe-inline'): punto animado de SignalTrace y
+	// barras de ScholarMetrics, calculados en el servidor y pasados por
+	// data-* attributes.
+	document.querySelectorAll('.signal-dot[data-offset-path]').forEach((dot) => {
+		dot.style.offsetPath = `path('${dot.dataset.offsetPath}')`;
+		if (dot.dataset.dotDuration) dot.style.animationDuration = `${dot.dataset.dotDuration}s`;
+	});
+
+	document.querySelectorAll('[data-bar-height]').forEach((bar) => {
+		bar.style.height = `${bar.dataset.barHeight}%`;
+	});
+
+	// Revelado suave al entrar en viewport (elementos .reveal y trazas .signal-trace)
+	// threshold: 0 — revela en cuanto entre cualquier parte del elemento.
+	// Un threshold > 0 impide revelar secciones más altas que el viewport
+	// (p. ej. la lista completa de publicaciones, de ~10.000 px).
+	const observer = new IntersectionObserver(
+		(entries) => {
+			entries.forEach((entry) => {
+				if (entry.isIntersecting) {
+					const path = entry.target.querySelector('.signal-trace-path');
+					if (path) path.classList.add('is-visible');
+					const dot = entry.target.querySelector('.signal-dot');
+					if (dot) dot.classList.add('is-visible');
+					entry.target.classList.add('is-visible');
+					observer.unobserve(entry.target);
+				}
+			});
+		},
+		{ threshold: 0, rootMargin: '0px 0px -10% 0px' }
+	);
+
+	document.querySelectorAll('.reveal, .signal-trace').forEach((el) => observer.observe(el));
+
+	// Al imprimir/exportar a PDF, forzar modo claro (independientemente del tema
+	// activo en pantalla) para que el documento impreso sea siempre legible.
+	let wasDark = false;
+	window.addEventListener('beforeprint', () => {
+		wasDark = document.documentElement.classList.contains('dark');
+		document.documentElement.classList.remove('dark');
+	});
+	window.addEventListener('afterprint', () => {
+		if (wasDark) document.documentElement.classList.add('dark');
+	});
+});

--- a/public/scripts/theme-init.js
+++ b/public/scripts/theme-init.js
@@ -1,0 +1,15 @@
+const theme = (() => {
+	if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
+		return localStorage.getItem('theme');
+	}
+	if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+		return 'dark';
+	}
+	return 'light';
+})();
+
+if (theme === 'dark') {
+	document.documentElement.classList.add('dark');
+} else {
+	document.documentElement.classList.remove('dark');
+}

--- a/src/components/BackToTop.astro
+++ b/src/components/BackToTop.astro
@@ -13,17 +13,3 @@ const { class: className = '' } = Astro.props;
 		<path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18" />
 	</svg>
 </button>
-
-<script>
-	const btn = document.getElementById('back-to-top');
-
-	function toggle() {
-		const show = window.scrollY > 400;
-		btn?.classList.toggle('!opacity-100', show);
-		btn?.classList.toggle('!translate-y-0', show);
-		btn?.classList.toggle('!pointer-events-auto', show);
-	}
-
-	window.addEventListener('scroll', toggle, { passive: true });
-	btn?.addEventListener('click', () => window.scrollTo({ top: 0, behavior: 'smooth' }));
-</script>

--- a/src/components/ScholarMetrics.astro
+++ b/src/components/ScholarMetrics.astro
@@ -157,8 +157,8 @@ const citationsMaxYear = citationsGraph.length > 0 ? Math.max(...citationsGraph.
                 <div class="flex-1 flex flex-col items-center gap-1.5 group">
                   <div class="w-full h-20 flex items-end">
                     <div
-                      class:list={['w-full rounded-sm transition-colors', isPeakYear ? 'bg-pulse-500' : 'bg-graphite-200 dark:bg-graphite-700 group-hover:bg-pulse-400']}
-                      style={`height: ${height}%`}
+                      class:list={['w-full rounded-sm transition-colors min-h-[2px]', isPeakYear ? 'bg-pulse-500' : 'bg-graphite-200 dark:bg-graphite-700 group-hover:bg-pulse-400']}
+                      data-bar-height={height}
                       title={`${year}: ${publications} publicaciones`}
                     />
                   </div>
@@ -190,8 +190,8 @@ const citationsMaxYear = citationsGraph.length > 0 ? Math.max(...citationsGraph.
                   <div class="flex-1 flex flex-col items-center gap-1.5 group">
                     <div class="w-full h-20 flex items-end">
                       <div
-                        class:list={['w-full rounded-sm transition-colors', isPeakYear ? 'bg-pulse-500' : 'bg-graphite-200 dark:bg-graphite-700 group-hover:bg-pulse-400']}
-                        style={`height: ${height}%`}
+                        class:list={['w-full rounded-sm transition-colors min-h-[2px]', isPeakYear ? 'bg-pulse-500' : 'bg-graphite-200 dark:bg-graphite-700 group-hover:bg-pulse-400']}
+                        data-bar-height={height}
                         title={`${year}: ${citations} citas`}
                       />
                     </div>

--- a/src/components/SignalTrace.astro
+++ b/src/components/SignalTrace.astro
@@ -109,7 +109,8 @@ const { d, peaks } = variant === 'ecg' ? ecgPath(width, height, beats) : edaPath
 			r={Math.max(2.5, strokeWidth * 1.4)}
 			class="signal-dot"
 			fill="#FF5A36"
-			style={{ offsetPath: `path('${d}')`, animationDuration: `${dotDuration}s` }}
+			data-offset-path={d}
+			data-dot-duration={dotDuration}
 		></circle>
 	)}
 </svg>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -8,7 +8,6 @@ const { class: className = '' } = Astro.props;
 ---
 
 <button
-  id="theme-toggle"
   class={`theme-toggle ${className}`}
   aria-label="Cambiar tema"
   title="Cambiar entre modo claro y oscuro"
@@ -64,21 +63,3 @@ const { class: className = '' } = Astro.props;
     @apply opacity-100;
   }
 </style>
-
-<script>
-  // Solo toggle — la lectura inicial y aplicación de tema la hace el inline script de Layout.astro
-  const toggle = document.getElementById('theme-toggle');
-  const html = document.documentElement;
-
-  toggle?.addEventListener('click', () => {
-    const next = html.classList.contains('dark') ? 'light' : 'dark';
-    html.classList.toggle('dark');
-    localStorage.setItem('theme', next);
-  });
-
-  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-    if (!localStorage.getItem('theme')) {
-      html.classList.toggle('dark', e.matches);
-    }
-  });
-</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -106,23 +106,7 @@ const navItems = [
 		<JsonLd />
 
 		<!-- Script para asegurar que no haya flash de modo incorrecto -->
-		<script is:inline>
-			const theme = (() => {
-				if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
-					return localStorage.getItem('theme');
-				}
-				if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-					return 'dark';
-				}
-				return 'light';
-			})();
-
-			if (theme === 'dark') {
-				document.documentElement.classList.add('dark');
-			} else {
-				document.documentElement.classList.remove('dark');
-			}
-		</script>
+		<script is:inline src="/scripts/theme-init.js"></script>
 	</head>
 	<body class="bg-paper dark:bg-ink text-graphite-700 dark:text-graphite-100 min-h-screen flex flex-col">
 		<a href="#main-content" class="skip-link">Saltar al contenido principal</a>
@@ -261,74 +245,6 @@ const navItems = [
 			</div>
 		</footer>
 
-		<script>
-			document.addEventListener('DOMContentLoaded', () => {
-				const mobileMenuButton = document.getElementById('mobile-menu-button');
-				const mobileMenu = document.getElementById('mobile-menu');
-
-				if (mobileMenuButton && mobileMenu) {
-					let isOpen = false;
-
-					const setOpen = (open: boolean, restoreFocus = false) => {
-						isOpen = open;
-						mobileMenu.classList.toggle('hidden', !open);
-						mobileMenuButton.setAttribute('aria-expanded', String(open));
-
-						if (open) {
-							mobileMenu.querySelector<HTMLElement>('a')?.focus();
-						} else if (restoreFocus) {
-							mobileMenuButton.focus();
-						}
-					};
-
-					mobileMenuButton.addEventListener('click', () => setOpen(!isOpen));
-
-					mobileMenu.querySelectorAll('a').forEach((link) => {
-						link.addEventListener('click', () => setOpen(false));
-					});
-
-					mobileMenu.addEventListener('keydown', (event) => {
-						if (event.key === 'Escape') setOpen(false, true);
-					});
-
-					window.addEventListener('resize', () => {
-						if (window.innerWidth >= 768 && isOpen) setOpen(false);
-					});
-				}
-
-				// Revelado suave al entrar en viewport (elementos .reveal y trazas .signal-trace)
-				// threshold: 0 — revela en cuanto entre cualquier parte del elemento.
-				// Un threshold > 0 impide revelar secciones más altas que el viewport
-				// (p. ej. la lista completa de publicaciones, de ~10.000 px).
-				const observer = new IntersectionObserver(
-					(entries) => {
-						entries.forEach((entry) => {
-							if (entry.isIntersecting) {
-								const path = entry.target.querySelector('.signal-trace-path');
-								if (path) path.classList.add('is-visible');
-								const dot = entry.target.querySelector('.signal-dot');
-								if (dot) dot.classList.add('is-visible');
-								entry.target.classList.add('is-visible');
-								observer.unobserve(entry.target);
-							}
-						});
-					},
-					{ threshold: 0, rootMargin: '0px 0px -10% 0px' }
-				);
-
-				document.querySelectorAll('.reveal, .signal-trace').forEach((el) => observer.observe(el));
-
-				// Al imprimir/exportar a PDF, forzar modo claro (independientemente del tema
-				// activo en pantalla) para que el documento impreso sea siempre legible.
-				let wasDark = false;
-				window.addEventListener('beforeprint', () => {
-					wasDark = document.documentElement.classList.contains('dark');
-					document.documentElement.classList.remove('dark');
-				});
-				window.addEventListener('afterprint', () => {
-					if (wasDark) document.documentElement.classList.add('dark');
-				});
-			});
-		</script>
+		<script is:inline src="/scripts/site.js"></script>
 	</body>
 </html>

--- a/src/pages/asignaturas.astro
+++ b/src/pages/asignaturas.astro
@@ -342,45 +342,5 @@ const recursos = [
 		</div>
 	</main>
 
-	<script>
-		document.addEventListener('DOMContentLoaded', () => {
-			const selectNivel = document.getElementById('nivel') as HTMLSelectElement;
-			const selectAnio = document.getElementById('anioAcademico') as HTMLSelectElement;
-			const inputBusqueda = document.getElementById('busqueda') as HTMLInputElement;
-			const cards = document.querySelectorAll<HTMLElement>('.subject-card');
-			const noResults = document.getElementById('noResults');
-			const resultCount = document.getElementById('resultCount');
-
-			const sections = document.querySelectorAll<HTMLElement>('.subject-section');
-
-			function applyFilters() {
-				const nivel = selectNivel?.value || 'todos';
-				const anio = selectAnio?.value || 'todos';
-				const busqueda = (inputBusqueda?.value || '').toLowerCase().trim();
-
-				let visible = 0;
-				cards.forEach((card) => {
-					const matchNivel = nivel === 'todos' || card.dataset.nivel === nivel;
-					const matchAnio = anio === 'todos' || card.dataset.anio === anio;
-					const matchBusqueda = !busqueda || (card.dataset.search || '').includes(busqueda);
-					const show = matchNivel && matchAnio && matchBusqueda;
-					card.classList.toggle('hidden', !show);
-					if (show) visible++;
-				});
-
-				// Oculta también la cabecera de un curso si ningún resultado suyo pasa el filtro.
-				sections.forEach((section) => {
-					const hasVisible = !!section.querySelector('.subject-card:not(.hidden)');
-					section.classList.toggle('hidden', !hasVisible);
-				});
-
-				if (resultCount) resultCount.textContent = `(${visible})`;
-				noResults?.classList.toggle('hidden', visible !== 0);
-			}
-
-			selectNivel?.addEventListener('change', applyFilters);
-			selectAnio?.addEventListener('change', applyFilters);
-			inputBusqueda?.addEventListener('input', applyFilters);
-		});
-	</script>
+	<script is:inline src="/scripts/asignaturas.js"></script>
 </Layout>

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -183,41 +183,4 @@ import Layout from '../layouts/Layout.astro';
 	<p id="form-feedback-text" class="text-sm text-graphite-500 dark:text-graphite-400"></p>
 </div>
 
-<script>
-	document.addEventListener('DOMContentLoaded', function() {
-		const form = document.getElementById('contact-form') as HTMLFormElement;
-		const submitButton = form?.querySelector('button[type="submit"]') as HTMLButtonElement;
-		const feedback = document.getElementById('form-feedback');
-		const feedbackTitle = document.getElementById('form-feedback-title');
-		const feedbackText = document.getElementById('form-feedback-text');
-
-		if (form && submitButton && feedback && feedbackTitle && feedbackText) {
-			form.addEventListener('submit', function(event) {
-				event.preventDefault();
-				submitButton.disabled = true;
-				submitButton.textContent = 'Enviando...';
-
-				const formData = new FormData(form);
-
-				fetch('/', {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-					body: new URLSearchParams(formData as any).toString(),
-				})
-					.then(() => {
-						form.classList.add('hidden');
-						feedback.classList.remove('hidden');
-						feedbackTitle.textContent = 'Mensaje enviado con exito';
-						feedbackText.textContent = 'Gracias por contactar. Te respondere en 24-48 horas.';
-					})
-					.catch(() => {
-						submitButton.disabled = false;
-						submitButton.textContent = 'Enviar mensaje';
-						feedback.classList.remove('hidden');
-						feedbackTitle.textContent = 'Error al enviar';
-						feedbackText.textContent = 'Intenta de nuevo o escribe a roberto.sanchez@uclm.es';
-					});
-			});
-		}
-	});
-</script>
+<script is:inline src="/scripts/contacto.js"></script>

--- a/src/pages/publicaciones.astro
+++ b/src/pages/publicaciones.astro
@@ -229,45 +229,4 @@ const uniqueYears = [...new Set(scholarData.publications.map(pub => pub.year).fi
   </div>
 </Layout>
 
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    const yearFilter = document.getElementById('yearFilter') as HTMLSelectElement;
-    const sortOrder = document.getElementById('sortOrder') as HTMLSelectElement;
-    const publicationsList = document.getElementById('publicationsList');
-    const publicationItems = document.querySelectorAll('.publication-item') as NodeListOf<HTMLElement>;
-
-    function filterPublications() {
-      if (!yearFilter) return;
-      const selectedYear = yearFilter.value;
-
-      publicationItems.forEach((item: HTMLElement) => {
-        const match = !selectedYear || item.dataset.year === selectedYear;
-        item.classList.toggle('hidden', !match);
-      });
-    }
-
-    function sortPublications() {
-      if (!sortOrder || !publicationsList) return;
-
-      const items = Array.from(publicationItems);
-      if (sortOrder.value === 'citations-desc') {
-        items.sort((a, b) =>
-          parseInt(b.dataset.citations || '0') - parseInt(a.dataset.citations || '0')
-        );
-      } else {
-        // Orden original del JSON (Scholar: fecha de publicación descendente)
-        items.sort((a, b) =>
-          parseInt(b.dataset.year || '0') - parseInt(a.dataset.year || '0')
-        );
-      }
-
-      items.forEach((item) => publicationsList.appendChild(item));
-    }
-
-    yearFilter?.addEventListener('change', filterPublications);
-    sortOrder?.addEventListener('change', sortPublications);
-
-    // Orden inicial: más citadas, todos los años
-    sortPublications();
-  });
-</script>
+<script is:inline src="/scripts/publicaciones.js"></script>

--- a/test/animations.test.js
+++ b/test/animations.test.js
@@ -9,6 +9,7 @@ describe('Sistema de diseño "traza de señal" y movimiento', () => {
   let projectRoot;
   let globalCss;
   let layoutContent;
+  let siteScriptContent;
   let signalTraceContent;
   let indexContent;
 
@@ -17,6 +18,9 @@ describe('Sistema de diseño "traza de señal" y movimiento', () => {
 
     globalCss = fs.readFileSync(path.join(projectRoot, 'src', 'styles', 'global.css'), 'utf8');
     layoutContent = fs.readFileSync(path.join(projectRoot, 'src', 'layouts', 'Layout.astro'), 'utf8');
+    // Los scripts de comportamiento viven en public/scripts/ (externos, no
+    // inline) para poder quitar 'unsafe-inline' de script-src en la CSP.
+    siteScriptContent = fs.readFileSync(path.join(projectRoot, 'public', 'scripts', 'site.js'), 'utf8');
     signalTraceContent = fs.readFileSync(path.join(projectRoot, 'src', 'components', 'SignalTrace.astro'), 'utf8');
     indexContent = fs.readFileSync(path.join(projectRoot, 'src', 'pages', 'index.astro'), 'utf8');
   });
@@ -39,9 +43,10 @@ describe('Sistema de diseño "traza de señal" y movimiento', () => {
   });
 
   describe('Revelado al hacer scroll', () => {
-    it('Layout observa los elementos .reveal y .signal-trace con IntersectionObserver', () => {
-      expect(layoutContent).toContain('IntersectionObserver');
-      expect(layoutContent).toContain("'.reveal, .signal-trace'");
+    it('Layout carga el script externo que observa .reveal y .signal-trace con IntersectionObserver', () => {
+      expect(layoutContent).toContain('src="/scripts/site.js"');
+      expect(siteScriptContent).toContain('IntersectionObserver');
+      expect(siteScriptContent).toContain("'.reveal, .signal-trace'");
     });
 
     it('la clase .reveal está definida como utilidad global', () => {

--- a/test/components.test.js
+++ b/test/components.test.js
@@ -94,13 +94,19 @@ describe('Componentes', () => {
   it('verifica el componente BackToTop', () => {
     const projectRoot = path.join(__dirname, '..');
     const backToTopPath = path.join(projectRoot, 'src', 'components', 'BackToTop.astro');
+    // El comportamiento (scroll listener + click) vive en public/scripts/site.js
+    // (script externo, no inline) para poder quitar 'unsafe-inline' de la CSP.
+    const siteScriptPath = path.join(projectRoot, 'public', 'scripts', 'site.js');
 
     expect(fs.existsSync(backToTopPath)).toBe(true);
+    expect(fs.existsSync(siteScriptPath)).toBe(true);
 
     const content = fs.readFileSync(backToTopPath, 'utf8');
     expect(content).toContain('id="back-to-top"');
     expect(content).toContain('aria-label');
-    expect(content).toContain('window.scrollTo');
+
+    const siteScript = fs.readFileSync(siteScriptPath, 'utf8');
+    expect(siteScript).toContain('window.scrollTo');
   });
 
   it('verifica archivos de documentación de mejoras', () => {


### PR DESCRIPTION
## Summary
- Externaliza todos los scripts de comportamiento a `public/scripts/` (theme-init.js, site.js, asignaturas.js, contacto.js, publicaciones.js), servidos como ficheros estáticos vía `<script is:inline src="/...">` — cubiertos por `script-src 'self'` sin hashes ni `unsafe-inline`
- De paso corrige un bug real: `ThemeToggle.astro` tenía `id="theme-toggle"` duplicado (dos botones, escritorio y móvil); con `getElementById` solo el primero tenía el listener enganchado. Ahora usa `querySelectorAll('.theme-toggle')`, así ambos botones funcionan
- `astro.config.mjs`: `inlineStylesheets` `'auto'` → `'never'` — el CSS nunca se inyecta como `<style>` inline (ya cubierto por la caché inmutable de `/_astro/*`)
- `SignalTrace.astro`/`ScholarMetrics.astro`: los estilos dinámicos por dato (offset-path del punto animado, altura de las barras) pasan de `style=""` inline a `data-*` attributes que `site.js` aplica en JS
- `netlify.toml`: CSP principal sin `unsafe-inline` en `script-src` ni `style-src` (la CSP del panel `/admin` de Sveltia no se toca)
- El JSON-LD (`application/ld+json`) no necesitó tratamiento especial: por spec no lo restringe `script-src`

## Test plan
- [x] `npm run build` sin errores
- [x] `npm test` — 132 tests en verde
- [x] Servido `dist/` con la CSP real (sin `unsafe-inline`) vía un servidor local + Playwright: **cero** errores de consola / violaciones de CSP
- [x] Probado interactivamente con la CSP real: toggle de tema (los dos botones, antes solo funcionaba uno), menú móvil con foco (abrir → foco al primer link; Escape → cierra y devuelve foco), back-to-top, animación de SignalTrace, barras de ScholarMetrics, filtros de asignaturas y publicaciones, formulario de contacto
- [ ] CI (`run-tests.yml`) en verde tras abrir esta PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)