### PR TITLE
Repara la generación del PDF del CV en el build de Netlify

### DIFF
--- a/content/cv.json
+++ b/content/cv.json
@@ -136,9 +136,9 @@
       "centro": "Instituto Politécnico de Leiria",
       "departamento": "",
       "pais": "Portugal",
-      "periodo": "",
-      "duracion": "",
-      "descripcion": "Estancia de investigación predoctoral."
+      "periodo": "Enero 2022 - Junio 2022",
+      "duracion": "6 meses",
+      "descripcion": "Estancia de investigación predoctoral desarrollando una arquitectura distribuida para el procesamiento de señales."
     }
   ],
   "gestionAcademica": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@astrojs/tailwind": "^6.0.2",
         "@babel/preset-env": "^7.27.2",
         "@babel/preset-typescript": "^7.27.1",
+        "@sparticuz/chromium": "^149.0.0",
         "@tailwindcss/typography": "^0.5.16",
         "astro": "^5.13.2",
         "babel-jest": "^29.7.0",
@@ -30,7 +31,7 @@
         "js-yaml": "^4.1.0",
         "jsdom": "^26.1.0",
         "pa11y-ci": "^2.4.2",
-        "puppeteer": "^25.4.0",
+        "puppeteer-core": "^25.4.0",
         "tailwindcss": "^3.4.17",
         "ts-jest": "^29.3.4"
       },
@@ -4541,6 +4542,19 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@sparticuz/chromium": {
+      "version": "149.0.0",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-149.0.0.tgz",
+      "integrity": "sha512-2NECBVKlUA9xIUXb4fT8OoGKdAJs+I2tNYscO8FwcxCKCWA7FmpPI0fdVxGJoIJglrFZYn+4YEJqChq4rdrxQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tar-fs": "^3.1.2"
+      },
+      "engines": {
+        "node": "^22.17.0 || >=24.0.0"
+      }
+    },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.16.tgz",
@@ -5202,6 +5216,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -5393,6 +5422,91 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
+      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base-64": {
       "version": "1.0.0",
@@ -6649,6 +6763,16 @@
         "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -6883,6 +7007,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -6970,6 +7104,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12409,6 +12550,17 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -12417,28 +12569,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/puppeteer": {
-      "version": "25.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.4.0.tgz",
-      "integrity": "sha512-xfQp8dFBcGaLc1hEMaVr7s+oW4ZkAurr8Y9H81ilKhu6QoLfSTkZjU7IavnyJ/VWpB9ni3KNJUQHUatslLWyGw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@puppeteer/browsers": "3.0.6",
-        "chromium-bidi": "17.0.2",
-        "devtools-protocol": "0.0.1653615",
-        "lilconfig": "^3.1.3",
-        "puppeteer-core": "25.4.0",
-        "typed-query-selector": "^2.12.2"
-      },
-      "bin": {
-        "puppeteer": "lib/puppeteer/node/cli.js"
-      },
-      "engines": {
-        "node": ">=22.12.0"
       }
     },
     "node_modules/puppeteer-core": {
@@ -13329,6 +13459,18 @@
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -13715,6 +13857,44 @@
         "node": ">=4"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -13728,6 +13908,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/thenify": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@astrojs/tailwind": "^6.0.2",
     "@babel/preset-env": "^7.27.2",
     "@babel/preset-typescript": "^7.27.1",
+    "@sparticuz/chromium": "^149.0.0",
     "@tailwindcss/typography": "^0.5.16",
     "astro": "^5.13.2",
     "babel-jest": "^29.7.0",
@@ -54,15 +55,11 @@
     "js-yaml": "^4.1.0",
     "jsdom": "^26.1.0",
     "pa11y-ci": "^2.4.2",
-    "puppeteer": "^25.4.0",
+    "puppeteer-core": "^25.4.0",
     "tailwindcss": "^3.4.17",
     "ts-jest": "^29.3.4"
   },
   "engines": {
     "node": ">=20"
-  },
-  "allowScripts": {
-    "puppeteer@1.19.0": true,
-    "puppeteer@25.4.0": true
   }
 }

--- a/scripts/generate-cv-pdf.js
+++ b/scripts/generate-cv-pdf.js
@@ -13,7 +13,8 @@
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
-import puppeteer from 'puppeteer';
+import os from 'node:os';
+import puppeteer from 'puppeteer-core';
 
 const DIST_DIR = path.resolve('dist');
 const OUTPUT_PATH = path.join(DIST_DIR, 'files', 'CV_RobertoSanchezReolid.pdf');
@@ -65,6 +66,26 @@ function startServer() {
   });
 }
 
+// En Linux (Netlify, GitHub Actions) usamos @sparticuz/chromium: un binario de
+// Chromium mínimo pensado para entornos restringidos, sin las librerías
+// compartidas (libnss3, libatk...) que un Chromium completo necesita y que
+// estos entornos de build no siempre tienen instaladas. En el resto de
+// plataformas (desarrollo local) usamos el Chrome ya instalado en el sistema,
+// sin depender de "puppeteer" ni de su descarga de ~200 MB.
+async function launchBrowser() {
+  if (os.platform() === 'linux') {
+    const chromium = (await import('@sparticuz/chromium')).default;
+
+    return puppeteer.launch({
+      headless: true,
+      args: chromium.args,
+      executablePath: await chromium.executablePath(),
+    });
+  }
+
+  return puppeteer.launch({ headless: true, channel: 'chrome' });
+}
+
 async function main() {
   if (!fs.existsSync(DIST_DIR)) {
     console.warn('[cv-pdf] dist/ no existe (¿se ejecutó "astro build" antes?). Se omite la generación del PDF.');
@@ -78,10 +99,7 @@ async function main() {
   let browser;
 
   try {
-    browser = await puppeteer.launch({
-      headless: true,
-      args: ['--no-sandbox', '--disable-setuid-sandbox'],
-    });
+    browser = await launchBrowser();
 
     const page = await browser.newPage();
     // Fuerza modo claro independientemente del prefers-color-scheme del entorno de build


### PR DESCRIPTION
## Resumen
- El PDF descargable del CV (`/files/CV_RobertoSanchezReolid.pdf`) daba 404 en producción.
- Causa raíz: el workflow "Deploy a Producción" de GitHub Actions no despliega nada (`Netlify credentials not provided, not deployable`); el despliegue real lo hace el build nativo de Netlify vía su integración con GitHub, donde Puppeteer no lograba arrancar el Chromium completo (faltan librerías del sistema en ese contenedor de build). El script silenciaba el error a propósito para no romper el despliegue, dejando el PDF sin generar.
- Fix: `generate-cv-pdf.js` usa ahora `puppeteer-core` + `@sparticuz/chromium` (binario mínimo para entornos restringidos) en Linux, y el Chrome del sistema (`channel: 'chrome'`) en el resto de plataformas. Se elimina la dependencia `puppeteer` (Chromium completo, ~200 MB).
- De paso: actualiza la estancia de investigación en Leiria (enero-junio 2022, 6 meses, arquitectura distribuida para procesamiento de señales).

## Plan de pruebas
- [x] `npm run build` genera `dist/files/CV_RobertoSanchezReolid.pdf` correctamente en local (macOS, vía Chrome del sistema)
- [ ] Verificar tras el deploy de Netlify que `https://marchanero.netlify.app/files/CV_RobertoSanchezReolid.pdf` responde 200 (antes daba 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)