### PR TITLE
Añade ficha de detalle por proyecto

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -49,6 +49,7 @@ collections:
     slug: '{{slug}}'
     summary: '{{titulo}} · {{estado}}'
     sortable_fields: ['titulo', 'fechaInicio', 'estado']
+    preview_path: 'proyectos/{{slug}}'
     fields:
       - { label: 'Título', name: 'titulo', widget: 'string' }
       - { label: 'Etiqueta para la home (p. ej. IA · EDUCACIÓN)', name: 'tag', widget: 'string', required: false }
@@ -67,7 +68,7 @@ collections:
       - { label: 'Financiación', name: 'financiacion', widget: 'string', required: false }
       - { label: 'Presupuesto', name: 'presupuesto', widget: 'string', required: false }
       - { label: 'Código de convocatoria (p. ej. PID2023-149753OB-C21)', name: 'codigo', widget: 'string', required: false }
-      - { label: 'URL de detalle', name: 'url', widget: 'string', required: false }
+      - { label: 'Página oficial (enlace externo, opcional — cada proyecto ya tiene ficha propia autogenerada en /proyectos/[slug])', name: 'url', widget: 'string', required: false }
       - label: 'Repositorios GitHub'
         name: 'github'
         widget: 'list'

--- a/src/pages/proyectos.astro
+++ b/src/pages/proyectos.astro
@@ -117,9 +117,7 @@ const repoName = (url: string) => url.replace(/\/$/, '').split('/').pop() || 'CÃ
 						</div>
 
 						<div class="flex flex-wrap gap-2">
-							{proyecto.url && (
-								<a href={proyecto.url} class="btn btn-primary btn-sm flex-1">Ver detalles completos</a>
-							)}
+							<a href={`/proyectos/${proyecto.id}`} class="btn btn-primary btn-sm flex-1">Ver ficha completa</a>
 							{proyecto.github.map((repo) => (
 								<a href={repo} target="_blank" rel="noopener noreferrer" class="btn btn-outline btn-sm">{repoName(repo)}</a>
 							))}
@@ -194,9 +192,7 @@ const repoName = (url: string) => url.replace(/\/$/, '').split('/').pop() || 'CÃ
 						)}
 
 						<div class="flex gap-2 flex-wrap">
-							{proyecto.url && (
-								<a href={proyecto.url} class="btn btn-primary btn-sm flex-1">Ver detalles completos</a>
-							)}
+							<a href={`/proyectos/${proyecto.id}`} class="btn btn-primary btn-sm flex-1">Ver ficha completa</a>
 							{proyecto.github.map((repo) => (
 								<a href={repo} target="_blank" rel="noopener noreferrer" class="btn btn-outline btn-sm" title={`Ver ${repoName(repo)} en GitHub`} aria-label={`Ver ${repoName(repo)} en GitHub`}>
 									<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">

--- a/src/pages/proyectos/[slug].astro
+++ b/src/pages/proyectos/[slug].astro
@@ -1,0 +1,181 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import SignalTrace from '../../components/SignalTrace.astro';
+import { getCollection, render } from 'astro:content';
+
+export async function getStaticPaths() {
+	const proyectos = await getCollection('proyectos');
+	return proyectos.map((proyecto) => ({
+		params: { slug: proyecto.id },
+		props: { proyecto },
+	}));
+}
+
+const { proyecto } = Astro.props;
+const {
+	titulo,
+	tag,
+	etiquetas,
+	descripcion,
+	fechaInicio,
+	fechaFin,
+	estado,
+	financiacion,
+	presupuesto,
+	codigo,
+	url,
+	github,
+	progreso,
+	resultados,
+} = proyecto.data;
+
+// "Contenido adicional" del CMS: cuerpo markdown opcional del .md, más allá
+// de los campos de la ficha (frontmatter).
+const { Content } = await render(proyecto);
+
+// Nombre del repo a partir de la URL de GitHub, para etiquetar cada botón
+// cuando un proyecto enlaza a varios repositorios.
+const repoName = (repoUrl: string) => repoUrl.replace(/\/$/, '').split('/').pop() || 'Código';
+---
+
+<Layout
+	title={`${titulo} - Dr. Roberto Sánchez Reolid`}
+	description={descripcion}
+>
+	<header class="relative border-b border-line dark:border-line-dark py-10 sm:py-16 hero-wash overflow-hidden">
+		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+			<a href="/proyectos" class="inline-flex items-center gap-1.5 font-mono text-xs uppercase tracking-wide text-graphite-500 dark:text-graphite-400 hover:text-pulse-600 dark:hover:text-pulse-400 transition-colors mb-6">
+				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M10 19l-7-7m0 0l7-7m-7 7h18" /></svg>
+				Volver a proyectos
+			</a>
+
+			{tag && <p class="eyebrow mb-3">{tag}</p>}
+			<h1 class="text-3xl sm:text-4xl lg:text-5xl font-display font-bold text-graphite-900 dark:text-white mb-4 leading-tight">
+				{titulo}
+			</h1>
+			<p class="text-lg text-graphite-600 dark:text-graphite-300 max-w-2xl leading-relaxed mb-8">
+				{descripcion}
+			</p>
+
+			<div class="readout max-w-2xl">
+				<div class="readout-cell">
+					<div class="readout-value text-lg sm:text-xl">{estado}</div>
+					<div class="readout-label">Estado</div>
+				</div>
+				<div class="readout-cell">
+					<div class="readout-value text-lg sm:text-xl">{fechaInicio}–{fechaFin}</div>
+					<div class="readout-label">Periodo</div>
+				</div>
+				<div class="readout-cell">
+					<div class="readout-value text-lg sm:text-xl">{progreso}%</div>
+					<div class="readout-label">Progreso</div>
+				</div>
+			</div>
+		</div>
+	</header>
+
+	<div class="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-16">
+		<section class="mb-12 reveal">
+			<div class="h-20 -mx-6 -mt-2 mb-6 px-6 text-signal-500 dark:text-signal-400 overflow-hidden">
+				<SignalTrace variant="ecg" width={800} height={70} beats={6} class="w-full" animate={false} />
+			</div>
+
+			{etiquetas.length > 0 && (
+				<div class="flex flex-wrap gap-2 mb-8">
+					{etiquetas.map((etiqueta) => (
+						<span class="font-mono text-xs border border-line dark:border-line-dark text-graphite-600 dark:text-graphite-300 px-2.5 py-1 rounded-md">
+							{etiqueta}
+						</span>
+					))}
+				</div>
+			)}
+
+			<div class="mb-8">
+				<div class="flex items-center justify-between text-xs font-mono mb-1.5">
+					<span class="text-graphite-500 dark:text-graphite-400">Progreso del proyecto</span>
+					<span class="text-pulse-700 dark:text-pulse-400">{progreso}%</span>
+				</div>
+				<div class="signal-meter">
+					{Array.from({ length: 10 }).map((_, i) => (
+						<span class:list={['signal-meter-tick', i < progreso / 10 && 'is-filled']}></span>
+					))}
+				</div>
+			</div>
+
+			<div class="spec-card mb-8">
+				<span class="spec-tick spec-tick-tl"></span>
+				<span class="spec-tick spec-tick-br"></span>
+				<dl class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+					<div>
+						<dt class="font-mono text-xs uppercase tracking-wide text-graphite-500 dark:text-graphite-400 mb-1">Financiación</dt>
+						<dd class="text-graphite-800 dark:text-graphite-100">{financiacion || '—'}</dd>
+					</div>
+					<div>
+						<dt class="font-mono text-xs uppercase tracking-wide text-graphite-500 dark:text-graphite-400 mb-1">Presupuesto</dt>
+						<dd class="text-graphite-800 dark:text-graphite-100 font-mono">{presupuesto || '—'}</dd>
+					</div>
+					<div>
+						<dt class="font-mono text-xs uppercase tracking-wide text-graphite-500 dark:text-graphite-400 mb-1">Código de convocatoria</dt>
+						<dd class="text-graphite-800 dark:text-graphite-100 font-mono">{codigo || '—'}</dd>
+					</div>
+					<div>
+						<dt class="font-mono text-xs uppercase tracking-wide text-graphite-500 dark:text-graphite-400 mb-1">Periodo</dt>
+						<dd class="text-graphite-800 dark:text-graphite-100">{fechaInicio} — {fechaFin}</dd>
+					</div>
+				</dl>
+			</div>
+
+			{proyecto.body && proyecto.body.trim().length > 0 && (
+				<div class="prose dark:prose-invert max-w-none mb-8">
+					<Content />
+				</div>
+			)}
+
+			{resultados.length > 0 && (
+				<div class="mb-8">
+					<h2 class="text-xl font-display font-bold text-graphite-900 dark:text-white mb-4">Resultados</h2>
+					<ul class="space-y-2.5">
+						{resultados.map((resultado) => (
+							<li class="text-graphite-600 dark:text-graphite-300 flex items-start gap-2.5">
+								<span class="w-1.5 h-1.5 rounded-full bg-signal-500 mt-2 shrink-0"></span>
+								<span>{resultado}</span>
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
+
+			<div class="flex flex-wrap gap-3">
+				{url && (
+					<a href={url} target="_blank" rel="noopener noreferrer" class="btn btn-primary">Página oficial</a>
+				)}
+				{github.map((repo) => (
+					<a href={repo} target="_blank" rel="noopener noreferrer" class="btn btn-outline" title={`Ver ${repoName(repo)} en GitHub`} aria-label={`Ver ${repoName(repo)} en GitHub`}>
+						<svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+							<path d="M12 0C5.374 0 0 5.373 0 12 0 17.302 3.438 21.8 8.207 23.387c.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
+						</svg>
+						{repoName(repo)}
+					</a>
+				))}
+			</div>
+		</section>
+
+		<section class="text-center reveal">
+			<div class="spec-card p-8">
+				<span class="spec-tick spec-tick-tl"></span>
+				<span class="spec-tick spec-tick-br"></span>
+				<h2 class="text-xl sm:text-2xl font-display font-bold text-graphite-900 dark:text-white mb-3">
+					¿Interesado en colaborar?
+				</h2>
+				<p class="text-graphite-600 dark:text-graphite-300 mb-6 max-w-2xl mx-auto">
+					Si tienes ideas para proyectos innovadores o quieres formar parte de nuestro equipo de investigación,
+					no dudes en ponerte en contacto conmigo.
+				</p>
+				<div class="flex flex-wrap justify-center gap-3">
+					<a href="/contacto" class="btn btn-primary">Contactar</a>
+					<a href="/proyectos" class="btn btn-outline">Ver todos los proyectos</a>
+				</div>
+			</div>
+		</section>
+	</div>
+</Layout>


### PR DESCRIPTION
## Resumen
- Nueva página `src/pages/proyectos/[slug].astro`: ficha individual por proyecto (estado, periodo, financiación, presupuesto, código, progreso, resultados, contenido markdown adicional del CMS, enlaces a página oficial/GitHub), generada vía `getStaticPaths` sobre la colección `proyectos` — cualquier proyecto nuevo obtiene su ficha automáticamente.
- `src/pages/proyectos.astro`: los botones "Ver detalles completos" enlazaban a `proyecto.url`, vacío en los 10 proyectos actuales, así que nunca funcionaban. Ahora enlazan siempre a la ficha interna `/proyectos/{id}`.
- `public/admin/config.yml`: campo `url` renombrado a "Página oficial (enlace externo, opcional)" para reflejar su nuevo rol secundario; añadido `preview_path` para previsualizar la ficha desde el CMS.

## Test plan
- [x] `npm run build` — genera las 10 páginas de detalle sin errores
- [x] `npm test` — 14 suites / 132 tests OK
- [x] `pa11y-ci` sobre 2 fichas de detalle — 0 errores (se corrigió un salto de jerarquía de encabezados h1→h3 en el CTA final, ahora h1→h2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)