### PR TITLE
Añade ficha de detalle por asignatura

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -206,6 +206,7 @@ collections:
     slug: '{{slug}}'
     summary: '{{titulo}} · {{codigo}}'
     sortable_fields: ['titulo', 'codigo', 'curso']
+    preview_path: 'asignaturas/{{slug}}'
     fields:
       - { label: 'Código', name: 'codigo', widget: 'string' }
       - { label: 'Título', name: 'titulo', widget: 'string' }

--- a/src/pages/asignaturas.astro
+++ b/src/pages/asignaturas.astro
@@ -238,10 +238,20 @@ const recursos = [
 											{asignatura.descripcion}
 										</p>
 
-										<div class="flex items-center justify-between pt-4 border-t border-line dark:border-line-dark">
-											<span class="text-xs text-graphite-500 dark:text-graphite-400">{asignatura.horario}</span>
-											<a href={asignatura.enlaceMateriales} target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1.5 text-sm font-medium text-pulse-700 dark:text-pulse-400 dark:hover:text-pulse-300">
-												Materiales
+										<div class="pt-4 border-t border-line dark:border-line-dark">
+											<div class="flex items-center justify-between mb-3">
+												<span class="text-xs font-mono text-graphite-500 dark:text-graphite-400">{asignatura.horario}</span>
+												{asignatura.enlaceMateriales && (
+													<a href={asignatura.enlaceMateriales} target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-xs text-graphite-500 dark:text-graphite-400 hover:text-pulse-600 dark:hover:text-pulse-400">
+														Materiales
+														<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+															<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+														</svg>
+													</a>
+												)}
+											</div>
+											<a href={`/asignaturas/${asignatura.id}`} class="inline-flex items-center gap-1.5 text-sm font-medium text-pulse-700 dark:text-pulse-400 dark:hover:text-pulse-300">
+												Ver ficha completa
 												<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 													<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path>
 												</svg>

--- a/src/pages/asignaturas/[slug].astro
+++ b/src/pages/asignaturas/[slug].astro
@@ -1,0 +1,166 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import SignalTrace from '../../components/SignalTrace.astro';
+import { getCollection, render } from 'astro:content';
+
+export async function getStaticPaths() {
+	const asignaturas = await getCollection('asignaturas');
+	return asignaturas.map((asignatura) => ({
+		params: { slug: asignatura.id },
+		props: { asignatura },
+	}));
+}
+
+const { asignatura } = Astro.props;
+const {
+	codigo,
+	titulo,
+	grado,
+	nivel,
+	curso,
+	cuatrimestre,
+	creditos,
+	academicYear,
+	descripcion,
+	temario,
+	horario,
+	enlaceMateriales,
+} = asignatura.data;
+
+const nivelLabel = { grado: 'Grado', master: 'Máster', doctorado: 'Doctorado' }[nivel] ?? nivel;
+
+// "Contenido adicional" del CMS: cuerpo markdown opcional del .md, más allá
+// de los campos de la ficha (frontmatter).
+const { Content } = await render(asignatura);
+
+const cursoJsonLd = {
+	'@context': 'https://schema.org',
+	'@type': 'Course',
+	courseCode: codigo || undefined,
+	name: titulo,
+	description: descripcion,
+	educationalCredentialAwarded: nivel,
+	provider: {
+		'@type': 'CollegeOrUniversity',
+		name: 'Universidad de Castilla-La Mancha',
+	},
+	hasCourseInstance: {
+		'@type': 'CourseInstance',
+		courseMode: 'onsite',
+		courseWorkload: `PT${creditos * 25}H`,
+	},
+};
+---
+
+<Layout
+	title={`${titulo} - Dr. Roberto Sánchez Reolid`}
+	description={descripcion}
+>
+	<script type="application/ld+json" set:html={JSON.stringify(cursoJsonLd)} />
+
+	<header class="relative border-b border-line dark:border-line-dark py-10 sm:py-16 hero-wash overflow-hidden">
+		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+			<a href="/asignaturas" class="inline-flex items-center gap-1.5 font-mono text-xs uppercase tracking-wide text-graphite-500 dark:text-graphite-400 hover:text-pulse-600 dark:hover:text-pulse-400 transition-colors mb-6">
+				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M10 19l-7-7m0 0l7-7m-7 7h18" /></svg>
+				Volver a docencia
+			</a>
+
+			<p class="eyebrow mb-3">{grado} · {nivelLabel}</p>
+			<h1 class="text-3xl sm:text-4xl lg:text-5xl font-display font-bold text-graphite-900 dark:text-white mb-4 leading-tight">
+				{titulo}
+			</h1>
+			<p class="text-lg text-graphite-600 dark:text-graphite-300 max-w-2xl leading-relaxed mb-8">
+				{descripcion}
+			</p>
+
+			<div class="readout max-w-2xl">
+				<div class="readout-cell">
+					<div class="readout-value text-lg sm:text-xl">{codigo}</div>
+					<div class="readout-label">Código</div>
+				</div>
+				<div class="readout-cell">
+					<div class="readout-value text-lg sm:text-xl">{creditos}</div>
+					<div class="readout-label">ECTS</div>
+				</div>
+				<div class="readout-cell">
+					<div class="readout-value text-lg sm:text-xl">{curso} · {cuatrimestre}</div>
+					<div class="readout-label">Curso · Cuatrimestre</div>
+				</div>
+			</div>
+		</div>
+	</header>
+
+	<div class="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-10 sm:py-16">
+		<section class="mb-12 reveal">
+			<div class="h-20 -mx-6 -mt-2 mb-6 px-6 text-signal-500 dark:text-signal-400 overflow-hidden">
+				<SignalTrace variant="eda" width={800} height={70} beats={6} class="w-full" animate={false} />
+			</div>
+
+			<div class="spec-card mb-8">
+				<span class="spec-tick spec-tick-tl"></span>
+				<span class="spec-tick spec-tick-br"></span>
+				<dl class="grid grid-cols-1 sm:grid-cols-2 gap-6">
+					<div>
+						<dt class="font-mono text-xs uppercase tracking-wide text-graphite-500 dark:text-graphite-400 mb-1">Cursos académicos impartidos</dt>
+						<dd class="text-graphite-800 dark:text-graphite-100">{academicYear.join(', ')}</dd>
+					</div>
+					<div>
+						<dt class="font-mono text-xs uppercase tracking-wide text-graphite-500 dark:text-graphite-400 mb-1">Horario</dt>
+						<dd class="text-graphite-800 dark:text-graphite-100">{horario || '—'}</dd>
+					</div>
+					<div>
+						<dt class="font-mono text-xs uppercase tracking-wide text-graphite-500 dark:text-graphite-400 mb-1">Grado</dt>
+						<dd class="text-graphite-800 dark:text-graphite-100">{grado}</dd>
+					</div>
+					<div>
+						<dt class="font-mono text-xs uppercase tracking-wide text-graphite-500 dark:text-graphite-400 mb-1">Nivel</dt>
+						<dd class="text-graphite-800 dark:text-graphite-100">{nivelLabel}</dd>
+					</div>
+				</dl>
+			</div>
+
+			{asignatura.body && asignatura.body.trim().length > 0 && (
+				<div class="prose dark:prose-invert max-w-none mb-8">
+					<Content />
+				</div>
+			)}
+
+			{temario.length > 0 && (
+				<div class="mb-8">
+					<h2 class="text-xl font-display font-bold text-graphite-900 dark:text-white mb-4">Temario</h2>
+					<ul class="space-y-2.5">
+						{temario.map((tema, i) => (
+							<li class="text-graphite-600 dark:text-graphite-300 flex items-start gap-3">
+								<span class="font-mono text-xs text-signal-500 dark:text-signal-400 mt-0.5 shrink-0">{String(i + 1).padStart(2, '0')}</span>
+								<span>{tema}</span>
+							</li>
+						))}
+					</ul>
+				</div>
+			)}
+
+			<div class="flex flex-wrap gap-3">
+				{enlaceMateriales && (
+					<a href={enlaceMateriales} target="_blank" rel="noopener noreferrer" class="btn btn-primary">Ver materiales</a>
+				)}
+			</div>
+		</section>
+
+		<section class="text-center reveal">
+			<div class="spec-card p-8">
+				<span class="spec-tick spec-tick-tl"></span>
+				<span class="spec-tick spec-tick-br"></span>
+				<h2 class="text-xl sm:text-2xl font-display font-bold text-graphite-900 dark:text-white mb-3">
+					¿Tienes dudas sobre esta asignatura?
+				</h2>
+				<p class="text-graphite-600 dark:text-graphite-300 mb-6 max-w-2xl mx-auto">
+					Consulta los horarios de tutoría o ponte en contacto conmigo directamente.
+				</p>
+				<div class="flex flex-wrap justify-center gap-3">
+					<a href="/contacto" class="btn btn-primary">Contactar</a>
+					<a href="/asignaturas" class="btn btn-outline">Ver todas las asignaturas</a>
+				</div>
+			</div>
+		</section>
+	</div>
+</Layout>


### PR DESCRIPTION
## Resumen
- Nueva página `src/pages/asignaturas/[slug].astro`: ficha individual por asignatura (código, ECTS, curso/cuatrimestre, cursos académicos impartidos, horario, temario numerado, enlace a materiales, contenido markdown adicional del CMS), generada vía `getStaticPaths` sobre la colección `asignaturas` — cualquier asignatura nueva obtiene su ficha automáticamente. Mismo patrón que la ficha de proyectos (PR #36).
- `src/pages/asignaturas.astro`: cada tarjeta añade un enlace "Ver ficha completa" hacia la ficha interna, sin quitar el enlace externo "Materiales" cuando `enlaceMateriales` existe.
- `public/admin/config.yml`: añadido `preview_path` a la colección `asignaturas` para previsualizar la ficha desde el CMS.

## Test plan
- [x] `npm run build` — genera las 8 páginas de detalle sin errores
- [x] `npm test` — 14 suites / 132 tests OK
- [x] `pa11y-ci` (WCAG2AA) sobre 4 fichas de detalle + listado — 0 errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)